### PR TITLE
Remove initial slash from current Path

### DIFF
--- a/src/React-Piwik.js
+++ b/src/React-Piwik.js
@@ -74,7 +74,7 @@ export default class Piwik {
   }
 
   track(loc) {
-    const currentPath = loc.path || (loc.pathname + loc.search);
+    const currentPath = loc.path || (loc.pathname + loc.search).replace(/^\//, '');
 
     if (this.previousPath === currentPath) {
       return;


### PR DESCRIPTION
I use hashHistory in react app. The page url is https://domain.com/context/#/form?lang=en

react-piwik calculate currentPath
```
const currentPath = loc.path || (loc.pathname + loc.search);
```
for my url currentPath is ```/form?lang=en```

Next piwik.js calculate full url after use 
```
push(['setCustomUrl', currentPath])
```
 in https://github.com/piwik/piwik/blob/3.x-dev/js/piwik.js#L3275 
 When url is absolute (first char is slash) add only schema and host
```
if (url.slice(0, 1) === '/') {
    return getProtocolScheme(baseUrl) + '://' + getHostName(baseUrl) + url;
}
```
so url reported to piwik.php is not correct  https://domain.com/form?lang=en (not contain context and hash)

My change remove initial slash from currentPath so piwik.js calculates the correct url (contain context and hash)