### PR TITLE
add support for react router 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-piwik",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Library that allow to connect piwik with the react-router and track custom events",
   "main": "lib/React-Piwik.js",
   "scripts": {

--- a/src/React-Piwik.js
+++ b/src/React-Piwik.js
@@ -81,7 +81,12 @@ export default class Piwik {
       this.track(initialPath);
     }
     this.unlistenFromHistory = history.listen((loc) => {
-      this.track(loc);
+      // History version 5 sendes update as a object
+      if(loc["location"] !== null) {
+        this.track(loc.location);
+      }else{
+        this.track(loc);
+      }
     });
 
     return history;


### PR DESCRIPTION
In version 5 of the history class updates was changed from sending 2 objects location and path, to a single object containing both.

This adds support for both versions.
fixing issue #46 